### PR TITLE
remove spurious unquote

### DIFF
--- a/project.janet
+++ b/project.janet
@@ -5,7 +5,7 @@
   :version "0.0.1"
   :url "https://github.com/mikebeller/janet-playground"
   :repo "git+https://github.com/mikebeller/janet-playground.git"
-  :dependencies ["https://github.com/swlkr/osprey", "https://github.com/janet-lang/spork"])
+  :dependencies ["https://github.com/swlkr/osprey" "https://github.com/janet-lang/spork"])
 
 (declare-binscript
   :main "playground"


### PR DESCRIPTION
jpm install currently fails with:

./project.janet:8:51: compile error: cannot use unquote here