### PR TITLE
Update for recent sporks and using janet.h near janet.c

### DIFF
--- a/playground.janet
+++ b/playground.janet
@@ -8,11 +8,13 @@
   []
   (try
     (do
-      (os/rm (path/join "build" "janet.js"))
-      (os/rm (path/join "build" "janet.wasm"))
-      (os/rm (path/join "build" "fmt.jimage"))
+      (each pth ["fmt.jimage" "janet.js" "janet.wasm"]
+        (def fuller-path (path/join "build" pth))
+        (when (os/stat fuller-path)
+          (os/rm fuller-path)))
       (os/rmdir "build"))
-    ([err] )))
+    ([err]
+      (eprintf "%s" err))))
 
 (defn build-fmt-image []
   (def env (require "spork/fmt"))

--- a/playground.janet
+++ b/playground.janet
@@ -10,13 +10,13 @@
     (do
       (os/rm (path/join "build" "janet.js"))
       (os/rm (path/join "build" "janet.wasm"))
-      (os/rm (path/join "build" "spork.jimage"))
+      (os/rm (path/join "build" "fmt.jimage"))
       (os/rmdir "build"))
     ([err] )))
 
-(defn build-spork-image []
-  (def env (require "spork"))
-  (spit "spork.jimage" (make-image env)))
+(defn build-fmt-image []
+  (def env (require "spork/fmt"))
+  (spit "fmt.jimage" (make-image env)))
 
 (defn build
   ```Build wasm module.  Emsdk must be installed and runnable in the current
@@ -26,7 +26,7 @@
   (when (nil? stat)
     (os/mkdir "build"))
   (os/cd "build")
-  (build-spork-image)
+  (build-fmt-image)
   (def result
     (try
       (do
@@ -34,11 +34,12 @@
           @["emcc" "-O2" "-o" "janet.js"
             (path/join ".." "janet" "janet.c")
             (path/join ".." "janet" "play.c")
-            "--embed-file" "spork.jimage"
+            (string "-I" (path/join ".." "janet"))
+            "--embed-file" "fmt.jimage"
             "-s" "EXPORTED_FUNCTIONS=['_run_janet']"
             "-s" "ALLOW_MEMORY_GROWTH=1"
             "-s" "AGGRESSIVE_VARIABLE_ELIMINATION=1"
-            "-s" "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall','cwrap']"]
+            "-s" "EXPORTED_RUNTIME_METHODS=['ccall','cwrap']"]
           :p))
       ([err] (eprint "Can't run emcc.  Ensure emcc is installed and in your path, and emsdk_env.sh has been sourced into your current environment"))))
   (when (not= result 0)

--- a/public/play.html
+++ b/public/play.html
@@ -23,7 +23,7 @@
 
                 function doFormatCode() {
                     let userCode = window.editor.getValue();
-                    let code = "(import ./spork);" + "\n(def usercode ``````````" + userCode + "``````````) (spork/fmt/format-print usercode)";
+                    let code = "(import ./fmt)" + "\n(def usercode ``````````" + userCode + "``````````) (fmt/format-print usercode)";
                     let result = window.run_janet_for_output(code);
                     const suffix = 'RESULT> nil\n';
                     if (!result.endsWith(suffix)) {


### PR DESCRIPTION
This PR has a few pieces:

1. Tweaks to get the `spork/fmt` parts working with recent versions of spork so that `./playground build` can complete.
2. A change to the `emcc` invocation to get it to look for the `janet.h` that lives next to the `janet.c` being used as part of the compilation 
3. A change to the `emcc` invocation to stop using `EXTRA_EXPORTED_RUNTIME_METHODS` as it seems it is [deprecated](https://emscripten.org/docs/tools_reference/settings_reference.html?highlight=extra_exported_runtime_methods#extra-exported-runtime-methods).
4. Removal of a `;` (splice).  Janet changed a bit back so `;` use is slightly different [1].  I think `janet-playground` may have had an unintentional `;` that was ok before, but recent versions of `janet` are not so happy with it.
5. A slight change to the `clean` subcommand so that removal of files works a bit better and error output is generated if there is a problem.

To explain a bit about the spork portion...

I think it may be that since spork started to have native modules, the following may have stopped working: https://github.com/MikeBeller/janet-playground/blob/1395259c352684c416c6012b428b00c3f728f5e7/playground.janet#L18-L19

One work-around is to just require `spork/fmt` which has no `.c` bits so that's what this PR does (along with other adjustments to get it to work).

---

[1] It may have been [this](https://github.com/janet-lang/janet/issues/1121).